### PR TITLE
Resolve #14 [Release] fix source\javadoc configuration in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
 	<description>Testing Tools To Level Down Your Tests</description>
 
 	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<gmaven-plugin.version>1.5</gmaven-plugin.version>
 		<groovy.version>2.4.3</groovy.version>
 	</properties>
@@ -56,6 +57,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -109,6 +111,19 @@
 						<configuration>
 							<pomFileName>pom.xml</pomFileName>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.4</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/src/main/java/org/whaka/data/Column.java
+++ b/src/main/java/org/whaka/data/Column.java
@@ -53,7 +53,7 @@ public final class Column<T> {
 	}
 
 	/**
-	 * Equal to {@link #getKey().getType()}
+	 * Equal to #getKey().getType()
 	 */
 	public Class<T> getType() {
 		return key.type;

--- a/src/main/java/org/whaka/util/UberMaps.java
+++ b/src/main/java/org/whaka/util/UberMaps.java
@@ -22,7 +22,7 @@ public class UberMaps {
 	}
 	
 	/**
-	 * <p>Create instance of the {@link UberMaps.Entry} that implements {@link Map.Entry}.
+	 * <p>Create instance of the {@link UberMaps.Entry} that implements {@link java.util.Map.Entry}.
 	 * <p><b>Note:</b> result entry is immutable!
 	 */
 	public static <K,V> Entry<K, V> entry(K key, V val) {
@@ -31,7 +31,7 @@ public class UberMaps {
 	
 	
 	/**
-	 * <p><b>Immutable</b> implementation of {@link Map.Entry}.
+	 * <p><b>Immutable</b> implementation of {@link java.util.Map.Map.Entry}.
 	 * 
 	 * <p>Entry also implements {@link Predicate} of a map, and tests whether specified map contains an entry
 	 * like this one: {@link Entry#test(Map)}.


### PR DESCRIPTION
1. Source plugin added to the POM
2. Source encoding info added to the POM
3. Compiler version added to the POM
4. Javadoc warnings are fixed
