### PR TITLE
Resolve #33 [Assert] Implement functionality for custom matchers to return custom results

### DIFF
--- a/src/main/java/org/whaka/asserts/AssertBuilder.java
+++ b/src/main/java/org/whaka/asserts/AssertBuilder.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.StringDescription;
+import org.whaka.asserts.matcher.ResultProvidingMatcher;
 
 /**
  * <p>Class provides ability to construct (or throw) an assert error with multiple assert results.
@@ -100,13 +101,22 @@ public class AssertBuilder {
 	 * @see #checkThat(Object, Matcher, String)
 	 */
 	public <T> AssertBuilder checkThat(T item, Matcher<T> matcher, String message, Throwable cause) {
-		if (!matcher.matches(item)) {
-			StringDescription expected = new StringDescription();
-			matcher.describeTo(expected);
-			if (item instanceof Throwable && cause == null)
-				cause = (Throwable) item;
-			addResult(new AssertResult(item, expected.toString(), message, cause));
-		}
+		if (!matcher.matches(item))
+			addResult(cresteResult(item, matcher, message, cause));
 		return this;
+	}
+	
+	private static <T> AssertResult cresteResult(T item, Matcher<T> matcher, String message, Throwable cause) {
+		if (matcher instanceof ResultProvidingMatcher)
+			return ((ResultProvidingMatcher<T>)matcher).createAssertResult(item, message, cause);
+		return createDefaultResult(item, matcher, message, cause);
+	}
+	
+	private static <T> AssertResult createDefaultResult(T item, Matcher<T> matcher, String message, Throwable cause) {
+		StringDescription expected = new StringDescription();
+		matcher.describeTo(expected);
+		if (item instanceof Throwable && cause == null)
+			cause = (Throwable) item;
+		return new AssertResult(item, expected.toString(), message, cause);
 	}
 }

--- a/src/main/java/org/whaka/asserts/matcher/ResultProvidingMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ResultProvidingMatcher.java
@@ -1,0 +1,9 @@
+package org.whaka.asserts.matcher;
+
+import org.hamcrest.BaseMatcher;
+import org.whaka.asserts.AssertResult;
+
+public abstract class ResultProvidingMatcher<T> extends BaseMatcher<T> {
+
+	public abstract AssertResult createAssertResult(T item, String message, Throwable cause);
+}

--- a/src/test/groovy/org/whaka/asserts/AssertBuilderTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/AssertBuilderTest.groovy
@@ -3,6 +3,7 @@ package org.whaka.asserts
 import static org.whaka.TestData.*
 
 import org.hamcrest.Matcher
+import org.whaka.asserts.matcher.ResultProvidingMatcher
 
 import spock.lang.Specification
 
@@ -265,5 +266,27 @@ class AssertBuilderTest extends Specification {
 			res.getExpected() == "qweqwe"
 			res.getMessage() == null
 			res.getCause().is(actual)
+	}
+
+	def "checkThat for ResultProvidingMatcher - custom result"() {
+		given:
+			ResultProvidingMatcher matcher = Mock()
+			AssertBuilder builder = new AssertBuilder()
+			Throwable cause = Mock()
+			AssertResult result = Mock()
+
+		when:
+			builder.checkThat(42, matcher, "msg", cause)
+		then:
+			1 * matcher.matches(42) >> false
+		and:
+			0 * matcher.describeTo(_)
+		and:
+			1 * matcher.createAssertResult(42, "msg", cause) >> result
+		and:
+			builder.getAssertResults().size() == 1
+			def res = builder.getAssertResults()[0]
+		and:
+			res.is(result)
 	}
 }


### PR DESCRIPTION
Special abstract kind of a matcher is implemented.
Builder functionality is changed for matchers of this type.
