### PR TITLE
Resolve #51 [Assert] Create "instanceOf" throwable matcher

### DIFF
--- a/src/main/java/org/whaka/asserts/AssertBuilder.java
+++ b/src/main/java/org/whaka/asserts/AssertBuilder.java
@@ -115,8 +115,6 @@ public class AssertBuilder {
 	private static <T> AssertResult createDefaultResult(T item, Matcher<T> matcher, String message, Throwable cause) {
 		StringDescription expected = new StringDescription();
 		matcher.describeTo(expected);
-		if (item instanceof Throwable && cause == null)
-			cause = (Throwable) item;
 		return new AssertResult(item, expected.toString(), message, cause);
 	}
 }

--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -1,5 +1,9 @@
 package org.whaka.asserts;
 
+import org.hamcrest.Matcher;
+import org.whaka.asserts.matcher.ThrowableMatcher;
+
+
 /**
  * Class provides static factory methods for custom Hamcrest matchers provided by the librabry.
  * 
@@ -8,5 +12,25 @@ package org.whaka.asserts;
 public final class UberMatchers {
 
 	private UberMatchers() {
+	}
+	
+	/**
+	 * Create a matcher that will check that an exception is an instance of the specified type.
+	 * And will set asserted throwable as cause of the result.
+	 * 
+	 * @see ThrowableMatcher
+	 */
+	public static Matcher<Throwable> throwableOfType(Class<? extends Throwable> type) {
+		return ThrowableMatcher.throwableOfType(type);
+	}
+	
+	/**
+	 * Create a matcher that will check that an exception is <code>null</code>.
+	 * And will set asserted throwable as cause of the result.
+	 * 
+	 * @see ThrowableMatcher
+	 */
+	public static Matcher<Throwable> notExpected() {
+		return ThrowableMatcher.notExpected();
 	}
 }

--- a/src/main/java/org/whaka/asserts/matcher/ThrowableMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ThrowableMatcher.java
@@ -1,0 +1,79 @@
+package org.whaka.asserts.matcher;
+
+import static java.util.Optional.*;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.whaka.asserts.AssertResult;
+
+/**
+ * <p>Class implements a {@link Matcher} that checks type of an exception. If specified expected type is <code>null</code>
+ * then matcher will expect <code>null</code> instead of actual throwable value.
+ * 
+ * <p>Difference from {@link Matchers#instanceOf(Class)} and {@link Matchers#nullValue()} is that this matcher
+ * sets asserted throwable as cause of the result.
+ * 
+ * <p>Also matcher produces more obvious (exception related) messages.
+ * 
+ * @see #throwableOfType(Class)
+ * @see #notExpected()
+ */
+public class ThrowableMatcher extends ResultProvidingMatcher<Throwable> {
+
+	private static final ThrowableMatcher NOT_EXPECTED = new ThrowableMatcher(null);
+	
+	private final Class<? extends Throwable> expectedType;
+	
+	private ThrowableMatcher(Class<? extends Throwable> expectedType) {
+		this.expectedType = expectedType;
+	}
+	
+	public Class<? extends Throwable> getExpectedType() {
+		return expectedType;
+	}
+	
+	@Override
+	public boolean matches(Object item) {
+		return getExpectedType() == null ? item == null : getExpectedType().isInstance(item);
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText(getExpectedMessage());
+	}
+	
+	private String getExpectedMessage() {
+		return getExpectedType() == null ? "no exception"
+				: "instance of " + getExpectedType().getCanonicalName();
+	}
+	
+	@Override
+	public AssertResult createAssertResult(Throwable item, String message, Throwable cause) {
+		Class<?> actual = ofNullable(item).map(Object::getClass).orElse(null);
+		if (cause == null)
+			cause = item;
+		return new AssertResult(actual, getExpectedMessage(), message, cause);
+	}
+	
+	/**
+	 * Creates an instance of {@link ThrowableMatcher} with specified type, as expected.
+	 * 
+	 * @see #notExpected()
+	 */
+	@Factory
+	public static ThrowableMatcher throwableOfType(Class<? extends Throwable> type) {
+		return type == null ? NOT_EXPECTED : new ThrowableMatcher(type);
+	}
+	
+	/**
+	 * Creates an instance of {@link ThrowableMatcher} with <code>null</code> as expected type.
+	 * 
+	 * @see #throwableOfType(Class)
+	 */
+	@Factory
+	public static ThrowableMatcher notExpected() {
+		return NOT_EXPECTED;
+	}
+}

--- a/src/main/java/org/whaka/util/Try.java
+++ b/src/main/java/org/whaka/util/Try.java
@@ -1,6 +1,6 @@
 package org.whaka.util;
 
-import static org.hamcrest.Matchers.*;
+import static org.whaka.asserts.UberMatchers.*;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -364,7 +364,7 @@ public class Try<R> {
 	 * @see #assertFailNotExpected()
 	 */
 	public Try<R> assertFailNotExpected(String message) {
-		return assertFail(nullValue(), message);
+		return assertFail(notExpected(), message);
 	}
 	
 	/**
@@ -382,7 +382,7 @@ public class Try<R> {
 	 * @see #assertFailIsInstanceOf(Class)
 	 */
 	public Try<R> assertFailIsInstanceOf(Class<? extends Exception> type, String message) {
-		return assertFail(instanceOf(type), message);
+		return assertFail(throwableOfType(type), message);
 	}
 	
 	@Override

--- a/src/test/groovy/org/whaka/asserts/AssertBuilderTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/AssertBuilderTest.groovy
@@ -246,28 +246,6 @@ class AssertBuilderTest extends Specification {
 			res.getCause() == null
 	}
 
-	def "checkThat for throwable adds cause"() {
-		given:
-			Matcher matcher = Mock()
-			AssertBuilder builder = new AssertBuilder()
-			def actual = new IllegalArgumentException()
-
-		when:
-			builder.checkThat(actual, matcher)
-		then:
-			1 * matcher.matches(actual) >> false
-		and:
-			1 * matcher.describeTo(_) >> {it[0].appendText("qweqwe")}
-		and:
-			builder.getAssertResults().size() == 1
-			def res = builder.getAssertResults()[0]
-		and:
-			res.getActual() == actual
-			res.getExpected() == "qweqwe"
-			res.getMessage() == null
-			res.getCause().is(actual)
-	}
-
 	def "checkThat for ResultProvidingMatcher - custom result"() {
 		given:
 			ResultProvidingMatcher matcher = Mock()

--- a/src/test/groovy/org/whaka/asserts/matcher/ThrowableMatcherTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/matcher/ThrowableMatcherTest.groovy
@@ -1,0 +1,72 @@
+package org.whaka.asserts.matcher
+
+import org.whaka.TestData
+
+import spock.lang.Specification
+
+class ThrowableMatcherTest extends Specification {
+
+	def "throwableOfType"() {
+		when:
+			def m1 = ThrowableMatcher.throwableOfType(cause?.getClass())
+		then:
+			m1 instanceof ThrowableMatcher
+			m1.getExpectedType() == cause?.getClass()
+		where:
+			cause << TestData.variousCauses()
+	}
+
+	def "notExpected"() {
+		expect:
+			ThrowableMatcher.notExpected().is(ThrowableMatcher.NOT_EXPECTED)
+			ThrowableMatcher.notExpected().is(ThrowableMatcher.throwableOfType(null))
+			ThrowableMatcher.notExpected().getExpectedType() == null
+	}
+
+	def "expected message"() {
+		given:
+			def m1 = ThrowableMatcher.throwableOfType(type)
+		expect:
+			m1.getExpectedMessage() == message
+		where:
+			type					|	message
+			null					|	"no exception"
+			RuntimeException		|	"instance of ${RuntimeException.class.getCanonicalName()}"
+			FileNotFoundException	|	"instance of ${FileNotFoundException.class.getCanonicalName()}"
+			AssertionError			|	"instance of ${AssertionError.class.getCanonicalName()}"
+			Throwable				|	"instance of ${Throwable.class.getCanonicalName()}"
+	}
+
+	def "matches"() {
+		given:
+			def m1 = ThrowableMatcher.throwableOfType(cause?.getClass())
+		expect:
+			m1.matches(cause)
+		where:
+			cause << TestData.variousCauses()
+	}
+
+	def "matches empty"() {
+		given:
+			def m1 = ThrowableMatcher.notExpected()
+		expect:
+			m1.matches(cause) == (cause == null)
+		where:
+			cause << TestData.variousCauses()
+	}
+
+	def "create result"() {
+		given:
+			def m1 = ThrowableMatcher.throwableOfType(RuntimeException)
+			def item = new RuntimeException("qwe")
+		when:
+			def res = m1.createAssertResult(item, "msg " + cause, cause)
+		then:
+			res.getActual() == item?.getClass()
+			res.getExpected() == "instance of ${RuntimeException.class.getCanonicalName()}"
+			res.getMessage() == "msg " + cause
+			res.getCause() == cause?:item
+		where:
+			cause << TestData.variousCauses()
+	}
+}

--- a/src/test/groovy/org/whaka/util/TryTest.groovy
+++ b/src/test/groovy/org/whaka/util/TryTest.groovy
@@ -680,7 +680,7 @@ class TryTest extends Specification {
 			res.getActual().is(cause)
 			res.getExpected() == "qwertyqaz"
 			res.getMessage() == "msg"
-			res.getCause().is(cause)
+			res.getCause() == null
 		where:
 			cause << CAUSES
 	}


### PR DESCRIPTION
- Resolves #50 [Assert] Create "unexpected" throwable matcher
- Resolves #51 [Assert] Create "instanceOf" throwable matcher
1. ThrowableMatcher is implemented.
2. AssertBuilder is refactored to not replace cause.
3. Try is refactored to use ThrowableMatcher.
# 

Blocked by: #56
