### PR TITLE
Resolve #36 [Assert] Create "consistent" matcher

### DIFF
--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -2,6 +2,7 @@ package org.whaka.asserts;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
+import org.whaka.asserts.matcher.ConsistencyMatcher;
 import org.whaka.asserts.matcher.ThrowableMatcher;
 
 
@@ -35,13 +36,11 @@ public final class UberMatchers {
 		return ThrowableMatcher.notExpected();
 	}
 	
-	/**
-	 * <p>If specified object is <code>null</code> - method returns {@link Matchers#nullValue()}.
-	 * Otherwise it returns {@link Matchers#notNullValue()}
-	 * 
-	 * <p>Factory method is useful in case you
-	 */
-	public static Matcher<Object> nullConsistentWith(Object other) {
-		return other == null ? Matchers.nullValue() : Matchers.notNullValue();
+	public static <T> Matcher<T> consistentWith(T value, Matcher<? super T> matcher) {
+		return new ConsistencyMatcher<T>(value, matcher);
+	}
+	
+	public static Matcher<Object> nullConsistentWith(Object value) {
+		return consistentWith(value, Matchers.nullValue());
 	}
 }

--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -1,6 +1,7 @@
 package org.whaka.asserts;
 
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.whaka.asserts.matcher.ThrowableMatcher;
 
 
@@ -32,5 +33,15 @@ public final class UberMatchers {
 	 */
 	public static Matcher<Throwable> notExpected() {
 		return ThrowableMatcher.notExpected();
+	}
+	
+	/**
+	 * <p>If specified object is <code>null</code> - method returns {@link Matchers#nullValue()}.
+	 * Otherwise it returns {@link Matchers#notNullValue()}
+	 * 
+	 * <p>Factory method is useful in case you
+	 */
+	public static Matcher<Object> nullConsistentWith(Object other) {
+		return other == null ? Matchers.nullValue() : Matchers.notNullValue();
 	}
 }

--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -36,10 +36,24 @@ public final class UberMatchers {
 		return ThrowableMatcher.notExpected();
 	}
 	
+	/**
+	 * Create a matcher that will check that tested item and specified value are either both consistently matched,
+	 * or both consistently not matched by the specified matcher.
+	 * 
+	 * @see #nullConsistentWith(Object)
+	 * @see ConsistencyMatcher
+	 */
 	public static <T> Matcher<T> consistentWith(T value, Matcher<? super T> matcher) {
 		return new ConsistencyMatcher<T>(value, matcher);
 	}
 	
+	/**
+	 * Create a matcher that will check that tested item and specified value are either both consistently <b>nulls</b>,
+	 * or both consistently <b>not-nulls</b>.
+	 * 
+	 * @see #consistentWith(Object, Matcher)
+	 * @see ConsistencyMatcher
+	 */
 	public static Matcher<Object> nullConsistentWith(Object value) {
 		return consistentWith(value, Matchers.nullValue());
 	}

--- a/src/main/java/org/whaka/asserts/matcher/ConsistencyMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ConsistencyMatcher.java
@@ -1,0 +1,42 @@
+package org.whaka.asserts.matcher;
+
+import static org.hamcrest.Matchers.*;
+
+import java.util.Objects;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+public class ConsistencyMatcher<T> extends BaseMatcher<T> {
+
+	private final T value;
+	private final Matcher<? super T> matcher;
+	private final Matcher<? super T> actualMatcher;
+	
+	public ConsistencyMatcher(T value, Matcher<? super T> matcher) {
+		this.value = value;
+		this.matcher = Objects.requireNonNull(matcher, "Delegate matcher cannot be null!");
+		this.actualMatcher = matcher.matches(value) ? matcher : not(matcher);
+	}
+	
+	public T getValue() {
+		return value;
+	}
+
+	public Matcher<? super T> getMatcher() {
+		return matcher;
+	}
+	
+	@Override
+	public boolean matches(Object item) {
+		return actualMatcher.matches(item);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void describeTo(Description description) {
+		actualMatcher.describeTo(description);
+		description.appendValueList(", just like <", "", ">", getValue());
+	}
+}

--- a/src/main/java/org/whaka/asserts/matcher/ConsistencyMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ConsistencyMatcher.java
@@ -8,6 +8,19 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
+/**
+ * <p>This {@link Matcher} will check that tested 'item' and predefined 'value' are either both consistently
+ * match specified delegate matcher, or both consistently doesn't match it.
+ * 
+ * <p>For example, if <code>Matchers.startsWith("q")</code> was used as delegate, then:
+ * <ul>
+ * 	<li>If predefined value is "qwe" - then matcher will expect any item that also starts with "q"
+ * 	<li>If predefined value is "rty" - then matcher will expect any item that also doesn't starts with "q"
+ * </ul>
+ * 
+ * <p>Matcher is useful in cases when you have a "model" value, and you need to test some item against it,
+ * by some predicates. Matcher also provides informative messages, about tested and predefined values.
+ */
 public class ConsistencyMatcher<T> extends BaseMatcher<T> {
 
 	private final T value;

--- a/src/test/groovy/org/whaka/asserts/matcher/ConsistencyMatcherTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/matcher/ConsistencyMatcherTest.groovy
@@ -31,32 +31,31 @@ class ConsistencyMatcherTest extends Specification {
 			value << TestData.variousObjects()
 	}
 
-	def "matches: itself"() {
-		given:
-			Matcher matcherPositive = Mock()
-			matcherPositive.matches(value) >> true
-		and:
-			Matcher matcherNegative = Mock()
-			matcherNegative.matches(value) >> false
-		and:
-			def mPositive = new ConsistencyMatcher(value, matcherPositive)
-			def mNegative = new ConsistencyMatcher(value, matcherNegative)
+	def "matches"() {
 
-		when:
-			def res1 = mPositive.matches(value)
-		then:
-			1 * matcherPositive.matches(value) >> true
-		and:
+		given: "a delegate matcher"
+			Matcher matcher = Mock()
+
+		when: "consistency matcher is create with a 'value' and a delegate"
+			def m = new ConsistencyMatcher("value", matcher)
+		then: "delegate is immediately asked to match the value 'value'"
+			1 * matcher.matches("value") >> initialMatch
+
+		when: "consistency matcher is asked to match an 'item'"
+			def res1 = m.matches("item1")
+		then: "delegate is also asked to match the 'item'"
+			1 * matcher.matches("item1") >> initialMatch
+		and: "if 'item' is matched the same way as 'value' - result is true"
 			res1 == true
 
 		when:
-			def res2 = mNegative.matches(value)
+			def res2 = m.matches("item2")
 		then:
-			1 * matcherNegative.matches(value) >> false
-		and:
-			res2 == true
+			1 * matcher.matches("item2") >> !initialMatch
+		and: "if 'item' is matched NOT the same way as 'value' - result is negative"
+			res2 == false
 
 		where:
-			value << TestData.variousObjects()
+			initialMatch << [true, false]
 	}
 }

--- a/src/test/groovy/org/whaka/asserts/matcher/ConsistencyMatcherTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/matcher/ConsistencyMatcherTest.groovy
@@ -1,0 +1,62 @@
+package org.whaka.asserts.matcher
+
+import org.hamcrest.Matcher
+import org.whaka.TestData
+
+import spock.lang.Specification
+
+class ConsistencyMatcherTest extends Specification {
+
+	def "construction"() {
+		given:
+			Matcher matcher = Mock()
+
+		when:
+			def mPositive = new ConsistencyMatcher(value, matcher)
+		then:
+			1 * matcher.matches(value) >> true
+		and:
+			mPositive.getValue().is(value)
+			mPositive.getMatcher().is(matcher)
+
+		when:
+			def mNegative = new ConsistencyMatcher(value, matcher)
+		then:
+			1 * matcher.matches(value) >> false
+		and:
+			mNegative.getValue().is(value)
+			mNegative.getMatcher().is(matcher)
+
+		where:
+			value << TestData.variousObjects()
+	}
+
+	def "matches: itself"() {
+		given:
+			Matcher matcherPositive = Mock()
+			matcherPositive.matches(value) >> true
+		and:
+			Matcher matcherNegative = Mock()
+			matcherNegative.matches(value) >> false
+		and:
+			def mPositive = new ConsistencyMatcher(value, matcherPositive)
+			def mNegative = new ConsistencyMatcher(value, matcherNegative)
+
+		when:
+			def res1 = mPositive.matches(value)
+		then:
+			1 * matcherPositive.matches(value) >> true
+		and:
+			res1 == true
+
+		when:
+			def res2 = mNegative.matches(value)
+		then:
+			1 * matcherNegative.matches(value) >> false
+		and:
+			res2 == true
+
+		where:
+			value << TestData.variousObjects()
+	}
+}


### PR DESCRIPTION
`ConsistencyMatcher` is implemented.
`UberMatchers.consistentWith(T, Matcher<T>)` and `UberMatchers.nullConsistentWith(Object)` are implemented.
