### PR TITLE
Number matchers

### DIFF
--- a/src/main/java/org/whaka/asserts/NumberMatchers.java
+++ b/src/main/java/org/whaka/asserts/NumberMatchers.java
@@ -20,10 +20,13 @@ import com.google.common.base.Suppliers;
 /**
  * Class provides static factory methods for custom Hamcrest matchers related to numbers.
  * 
+ * @see DoubleMath
  * @see UberMatchers
  */
 public final class NumberMatchers {
 
+	// Memoizers are used to ensure "invariant" matchers are instantiated on demand, BUT only once
+	
 	private static final Supplier<Matcher<Double>> IS_NUMBER = Suppliers.memoize(
 			() -> new FunctionalMatcher<>(Double.class, DoubleMath::isNumber, "number"));
 	
@@ -42,22 +45,42 @@ public final class NumberMatchers {
 	private NumberMatchers() {
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#isNumber(Double)}.
+	 * Matches if item is <b>not null</b> and <b>not {@link Double#NaN}</b>
+	 */
 	public static Matcher<Double> number() {
 		return IS_NUMBER.get();
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#isFinite(Double)}.
+	 * Matches if item is <b>not null</b>, <b>not {@link Double#NaN}</b>, and <b>is finite</b>.
+	 */
 	public static Matcher<Double> finite() {
 		return IS_FINITE.get();
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#isZero(Double)}.
+	 * Matches if item is <b>not null</b> and <b>equal to 0.0</b>.
+	 */
 	public static Matcher<Number> zero() {
 		return IS_ZERO.get();
 	}
 	
+	/**
+	 * <p>Matcher equivalent of the {@link DoubleMath#isPositive(Double)}.
+	 * Matches if item is <b>number</b> and <b>greater than 0.0</b>.
+	 */
 	public static Matcher<Number> positive() {
 		return IS_POSITIVE.get();
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#isNegative(Double)}.
+	 * Matches if item is <b>number</b> and <b>lower than 0.0</b>.
+	 */
 	public static Matcher<Number> negative() {
 		return IS_NEGATIVE.get();
 	}
@@ -66,6 +89,10 @@ public final class NumberMatchers {
 		return a -> delegate.test(asDouble(a));
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#equals(Double, Double)}.
+	 * Matches if item is <b>double-equal</b> to the specified number value.
+	 */
 	public static Matcher<Number> equalTo(Number value) {
 		return new FunctionalMatcher<>(Number.class,
 				convertBiPredicate(DoubleMath::equals, value),
@@ -76,18 +103,42 @@ public final class NumberMatchers {
 		return a -> delegate.test(asDouble(a), asDouble(value));
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#compare(double, double)}.
+	 * Matches if item is <b>not-null</b>, and <b>double-greater</b> than specified number value.
+	 * 
+	 * @throws NullPointerException if specified value is <code>null</code>
+	 */
 	public static Matcher<Number> greaterThan(Number value) {
 		return createCompareMatcher(value, i -> i > 0, "greater than");
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#compare(double, double)}.
+	 * Matches if item is <b>not-null</b>, and <b>double-lower</b> than specified number value.
+	 * 
+	 * @throws NullPointerException if specified value is <code>null</code>
+	 */
 	public static Matcher<Number> lowerThan(Number value) {
 		return createCompareMatcher(value, i -> i < 0, "lower than");
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#compare(double, double)}.
+	 * Matches if item is <b>not-null</b>, and <b>double-greater</b> than or <b>double-equal</b> to the specified number value.
+	 * 
+	 * @throws NullPointerException if specified value is <code>null</code>
+	 */
 	public static Matcher<Number> greaterThanOrEqual(Number value) {
 		return createCompareMatcher(value, i -> i >= 0, "greater than or equal to");
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#compare(double, double)}.
+	 * Matches if item is <b>not-null</b>, and <b>double-lower</b> than or <b>double-equal</b> to the specified number value.
+	 * 
+	 * @throws NullPointerException if specified value is <code>null</code>
+	 */
 	public static Matcher<Number> lowerThanOrEqual(Number value) {
 		return createCompareMatcher(value, i -> i <= 0, "lower than or equal to");
 	}
@@ -107,10 +158,26 @@ public final class NumberMatchers {
 		return d -> d.appendText(String.format("number %s ", operationName)).appendValue(value);
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#compare(double, double)} for two bound arguments.
+	 * Matches if item is <b>double-greater</b> than first specified number,
+	 * or <b>double-greater</b> than second specified argument.
+	 * 
+	 * @throws NullPointerException if either specified value is <code>null</code>
+	 * @throws IllegalArgumentException if specified min is greater than specified max
+	 */
 	public static Matcher<Number> between(Number min, Number max) {
 		return createBiCompareMatcher(min, max, (a, b) -> a > 0 && b < 0, "number between");
 	}
 	
+	/**
+	 * Matcher equivalent of the {@link DoubleMath#compare(double, double)} for two bound arguments.
+	 * Matches if item is <b>double-greater</b> than first specified number,
+	 * or <b>double-greater</b> than second specified argument, or <b>double-equal</b> to any of them.
+	 * 
+	 * @throws NullPointerException if either specified value is <code>null</code>
+	 * @throws IllegalArgumentException if specified min is greater than specified max
+	 */
 	public static Matcher<Number> betweenOrEqual(Number min, Number max) {
 		return createBiCompareMatcher(min, max, (a, b) -> a >= 0 && b <= 0, "number between or equal");
 	}

--- a/src/main/java/org/whaka/asserts/NumberMatchers.java
+++ b/src/main/java/org/whaka/asserts/NumberMatchers.java
@@ -13,6 +13,7 @@ import org.hamcrest.Matcher;
 import org.whaka.asserts.matcher.FunctionalMatcher;
 import org.whaka.util.DoubleMath;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 
@@ -117,6 +118,7 @@ public final class NumberMatchers {
 	private static Matcher<Number> createBiCompareMatcher(Number min, Number max, BiPredicate<Integer, Integer> predicate, String op) {
 		Objects.requireNonNull(min, "Cannot compare to null!");
 		Objects.requireNonNull(max, "Cannot compare to null!");
+		Preconditions.checkArgument(DoubleMath.compare(asDouble(min), asDouble(max)) <= 0, "min is greater than max!");
 		return new FunctionalMatcher<>(Number.class,
 				convertBiCompareResultPredicate(predicate, min, max),
 				createBiCompareDescriber(op, min, max));

--- a/src/main/java/org/whaka/asserts/NumberMatchers.java
+++ b/src/main/java/org/whaka/asserts/NumberMatchers.java
@@ -1,5 +1,18 @@
 package org.whaka.asserts;
 
+import static org.whaka.util.DoubleMath.*;
+
+import java.util.Objects;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.whaka.asserts.matcher.FunctionalMatcher;
+import org.whaka.util.DoubleMath;
+
 /**
  * Class provides static factory methods for custom Hamcrest matchers related to numbers.
  * 
@@ -8,5 +21,105 @@ package org.whaka.asserts;
 public final class NumberMatchers {
 
 	private NumberMatchers() {
+	}
+	
+	public static Matcher<Double> number() {
+		return new FunctionalMatcher<>(Double.class, DoubleMath::isNumber, createNameDescriber("number"));
+	}
+	
+	public static Matcher<Double> finite() {
+		return new FunctionalMatcher<>(Double.class, DoubleMath::isFinite, createNameDescriber("finite number"));
+	}
+	
+	public static Matcher<Number> zero() {
+		return new FunctionalMatcher<>(Number.class, convertPredicate(DoubleMath::isZero), d -> d.appendValue(0));
+	}
+	
+	public static Matcher<Number> positive() {
+		return new FunctionalMatcher<>(Number.class, convertPredicate(DoubleMath::isPositive), createNameDescriber("positive number"));
+	}
+	
+	public static Matcher<Number> negative() {
+		return new FunctionalMatcher<>(Number.class, convertPredicate(DoubleMath::isPositive), createNameDescriber("negative number"));
+	}
+	
+	private static Predicate<Number> convertPredicate(Predicate<Double> delegate) {
+		return a -> delegate.test(asDouble(a));
+	}
+	
+	private static Consumer<Description> createNameDescriber(String operationName) {
+		return d -> d.appendText(operationName);
+	}
+	
+	public static Matcher<Number> equalTo(Number value) {
+		return new FunctionalMatcher<>(Number.class,
+				convertBiPredicate(DoubleMath::equals, value),
+				createSingleValueDescriber("equal to", value));
+	}
+	
+	private static Predicate<Number> convertBiPredicate(BiPredicate<Double, Double> delegate, Number value) {
+		return a -> delegate.test(asDouble(a), asDouble(value));
+	}
+	
+	public static Matcher<Number> greaterThan(Number value) {
+		Objects.requireNonNull(value, "Cannot compare to null!");
+		return new FunctionalMatcher<>(Number.class,
+				convertCompareResultPredicate(i -> i > 0, value),
+				createSingleValueDescriber("greater than", value));
+	}
+	
+	public static Matcher<Number> lowerThan(Number value) {
+		Objects.requireNonNull(value, "Cannot compare to null!");
+		return new FunctionalMatcher<>(Number.class,
+				convertCompareResultPredicate(i -> i < 0, value),
+				createSingleValueDescriber("lower than", value));
+	}
+	
+	public static Matcher<Number> greaterThanOrEqual(Number value) {
+		Objects.requireNonNull(value, "Cannot compare to null!");
+		return new FunctionalMatcher<>(Number.class,
+				convertCompareResultPredicate(i -> i >= 0, value),
+				createSingleValueDescriber("greater than or equal to", value));
+	}
+	
+	public static Matcher<Number> lowerThanOrEqual(Number value) {
+		Objects.requireNonNull(value, "Cannot compare to null!");
+		return new FunctionalMatcher<>(Number.class,
+				convertCompareResultPredicate(i -> i <= 0, value),
+				createSingleValueDescriber("lower than or equal to", value));
+	}
+	
+	private static Predicate<Number> convertCompareResultPredicate(IntPredicate predicate, Number value) {
+		return convertBiPredicate((a, b) -> a != null && b != null && predicate.test(DoubleMath.compare(a, b)), value);
+	}
+	
+	private static Consumer<Description> createSingleValueDescriber(String operationName, Number value) {
+		return d -> d.appendText(String.format("number %s ", operationName)).appendValue(value);
+	}
+	
+	public static Matcher<Number> between(Number min, Number max) {
+		Objects.requireNonNull(min, "Cannot compare to null!");
+		Objects.requireNonNull(max, "Cannot compare to null!");
+		return new FunctionalMatcher<>(Number.class,
+				convertBiCompareResultPredicate((a, b) -> a > 0 && b < 0, min, max),
+				createBiCompareDescriber("<>", min, max));
+	}
+	
+	public static Matcher<Number> betweenOrEqual(Number min, Number max) {
+		Objects.requireNonNull(min, "Cannot compare to null!");
+		Objects.requireNonNull(max, "Cannot compare to null!");
+		return new FunctionalMatcher<>(Number.class,
+				convertBiCompareResultPredicate((a, b) -> a >= 0 && b <= 0, min, max),
+				createBiCompareDescriber("<=>", min, max));
+	}
+	
+	private static Predicate<Number> convertBiCompareResultPredicate(BiPredicate<Integer, Integer> predicate, Number a, Number b) {
+		return convertPredicate(x -> x != null && predicate.test(
+				DoubleMath.compare(x, asDouble(a)),
+				DoubleMath.compare(x, asDouble(b))));
+	}
+	
+	private static Consumer<Description> createBiCompareDescriber(String operationName, Number min, Number max) {
+		return d -> d.appendValue(min).appendText(String.format(" % ", operationName)).appendValue(max);
 	}
 }

--- a/src/main/java/org/whaka/asserts/matcher/FunctionalMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/FunctionalMatcher.java
@@ -1,0 +1,44 @@
+package org.whaka.asserts.matcher;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+public class FunctionalMatcher<T> extends BaseMatcher<T> {
+
+	private final Class<T> type;
+	private final Predicate<T> predicate;
+	private final Consumer<Description> describer;
+	
+	public FunctionalMatcher(Class<T> type, Predicate<T> predicate, Consumer<Description> describer) {
+		this.type = Objects.requireNonNull(type, "type");
+		this.predicate = Objects.requireNonNull(predicate, "predicate");
+		this.describer = Objects.requireNonNull(describer, "describer");
+	}
+	
+	public Class<T> getType() {
+		return type;
+	}
+	
+	public Predicate<T> getPredicate() {
+		return predicate;
+	}
+	
+	public Consumer<Description> getDescriber() {
+		return describer;
+	}
+	
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean matches(Object item) {
+		return (item == null || getType().isInstance(item)) && getPredicate().test((T) item);
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		getDescriber().accept(description);
+	}
+}

--- a/src/main/java/org/whaka/asserts/matcher/FunctionalMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/FunctionalMatcher.java
@@ -6,13 +6,46 @@ import java.util.function.Predicate;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 
+/**
+ * <p>Class allows to create instances of the {@link Matcher}
+ * using functional interfaces to delegate actual functionality.
+ * 
+ * <p>Three components are required to create a matcher:
+ * <ul>
+ * 	<li>Type of matched items
+ * 	<li>Predicate of an item, to perform actual matching
+ * 	<li>Description, providing some information about a matcher
+ * </ul>
+ * 
+ * @see #FunctionalMatcher(Class, Predicate, Consumer)
+ * @see #FunctionalMatcher(Class, Predicate, String)
+ */
 public class FunctionalMatcher<T> extends BaseMatcher<T> {
 
 	private final Class<T> type;
 	private final Predicate<T> predicate;
 	private final Consumer<Description> describer;
 	
+	/**
+	 * Equal to the {@link #FunctionalMatcher(Class, Predicate, Consumer)} but with an automatically created
+	 * consumer that calls {@link Description#appendText(String)} with the specified string.
+	 * 
+	 */
+	public FunctionalMatcher(Class<T> type, Predicate<T> predicate, String description) {
+		this(type, predicate, d -> d.appendText(description));
+	}
+	
+	/**
+	 * To create an instance of the functional matcher you have to specify a {@link Class} of items,
+	 * for Hamcrest's matchers don't perform any basic type assertion; a {@link Predicate} of the same type,
+	 * that will be called for each item that's either <code>null</code>, or an instance of the specified class;
+	 * and a {@link Consumer} for the {@link Description} type, that will be called each time matcher have to describe
+	 * itself.
+	 * 
+	 * @see #FunctionalMatcher(Class, Predicate, String)
+	 */
 	public FunctionalMatcher(Class<T> type, Predicate<T> predicate, Consumer<Description> describer) {
 		this.type = Objects.requireNonNull(type, "type");
 		this.predicate = Objects.requireNonNull(predicate, "predicate");

--- a/src/test/groovy/org/whaka/asserts/NumberMatchersTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/NumberMatchersTest.groovy
@@ -1,0 +1,346 @@
+package org.whaka.asserts
+
+import java.util.function.BiFunction
+import java.util.function.Function
+import java.util.function.Supplier
+
+import org.hamcrest.Matcher
+
+import spock.lang.Specification
+
+class NumberMatchersTest extends Specification {
+
+	private static final Double PINF = Double.POSITIVE_INFINITY
+	private static final Double NINF = Double.NEGATIVE_INFINITY
+	private static final Double MAX = Double.MAX_VALUE
+	private static final Double MIN = Double.MIN_VALUE
+	private static final Double NAN = Double.NaN
+
+	def "invariant instances are memoized"() {
+		given:
+			Supplier<Matcher> getter = _getter
+			com.google.common.base.Supplier<Matcher> supplier = _supplier
+		expect:
+			getter.get().is(getter.get())
+			getter.get().is(supplier.get())
+		where:
+			_getter						|	_supplier
+			NumberMatchers.&number		|	NumberMatchers.IS_NUMBER
+			NumberMatchers.&finite		|	NumberMatchers.IS_FINITE
+			NumberMatchers.&zero		|	NumberMatchers.IS_ZERO
+			NumberMatchers.&positive	|	NumberMatchers.IS_POSITIVE
+			NumberMatchers.&negative	|	NumberMatchers.IS_NEGATIVE
+	}
+
+	def "comparison NPE"() {
+		given:
+			Function<Number, Matcher> factory = _factory
+		when:
+			factory.apply(null as Number)
+		then:
+			thrown(NullPointerException)
+		where:
+			_factory << [
+				NumberMatchers.&greaterThan,
+				NumberMatchers.&lowerThan,
+				NumberMatchers.&greaterThanOrEqual,
+				NumberMatchers.&lowerThanOrEqual,
+			]
+	}
+
+	def "bicomparison NPE"() {
+		given:
+			BiFunction<Number, Number, Matcher> factory = _factory
+
+		when:
+			factory.apply(null as Number, 42)
+		then:
+			thrown(NullPointerException)
+
+		when:
+			factory.apply(42, null as Number)
+		then:
+			thrown(NullPointerException)
+
+		when:
+			factory.apply(null as Number, null as Number)
+		then:
+			thrown(NullPointerException)
+
+		where:
+			_factory << [
+				NumberMatchers.&between,
+				NumberMatchers.&betweenOrEqual,
+			]
+	}
+
+	def "bicomparison: min <= max assert"() {
+		given:
+			BiFunction<Number, Number, Matcher> factory = _factory
+
+		when:
+			factory.apply(41, 42)
+		then:
+			notThrown()
+
+		when:
+			factory.apply(42, 42)
+		then:
+			notThrown()
+
+		when:
+			factory.apply(43, 42)
+		then:
+			thrown(IllegalArgumentException)
+
+		where:
+			_factory << [
+				NumberMatchers.&between,
+				NumberMatchers.&betweenOrEqual,
+			]
+	}
+
+	def "number"() {
+		given:
+			Matcher m = NumberMatchers.number()
+		expect:
+			m.matches(item as Double) == result
+		where:
+			item		|	result
+			0			|	true
+			-10000000	|	true
+			+10000000	|	true
+			MAX			|	true
+			MIN			|	true
+			PINF		|	true
+			NINF		|	true
+			NAN			|	false
+			null		|	false
+	}
+
+	def "finite"() {
+		given:
+			Matcher m = NumberMatchers.finite()
+		expect:
+			m.matches(item as Double) == result
+		where:
+			item		|	result
+			0			|	true
+			-10000000	|	true
+			+10000000	|	true
+			MAX			|	true
+			MIN			|	true
+			PINF		|	false
+			NINF		|	false
+			NAN			|	false
+			null		|	false
+	}
+
+	def "positive"() {
+		given:
+			Matcher m = NumberMatchers.positive()
+		expect:
+			m.matches(item as Number) == result
+		where:
+			item		|	result
+			0			|	false
+			-10000000	|	false
+			+10000000	|	true
+			MAX			|	true
+			MIN			|	false
+			-MAX		|	false
+			-MIN		|	false
+			PINF		|	true
+			NINF		|	false
+			NAN			|	false
+			null		|	false
+	}
+
+	def "negative"() {
+		given:
+			Matcher m = NumberMatchers.negative()
+		expect:
+			m.matches(item as Number) == result
+		where:
+			item		|	result
+			0			|	false
+			-10000000	|	true
+			+10000000	|	false
+			MAX			|	false
+			MIN			|	false
+			-MAX		|	true
+			-MIN		|	false
+			PINF		|	false
+			NINF		|	true
+			NAN			|	false
+			null		|	false
+	}
+
+	def "zero"() {
+		given:
+			Matcher m = NumberMatchers.zero()
+		expect:
+			m.matches(item as Number) == result
+		where:
+			item		|	result
+			0			|	true
+			-10000000	|	false
+			+10000000	|	false
+			MAX			|	false
+			MIN			|	true
+			-MAX		|	false
+			-MIN		|	true
+			PINF		|	false
+			NINF		|	false
+			NAN			|	false
+			null		|	false
+	}
+
+	def "equalTo"() {
+		given:
+			Matcher m = NumberMatchers.equalTo(value as Number)
+		expect:
+			m.matches(item as Number) == result
+		where:
+			item				|	value			||	result
+			0					|	0				||	true
+			MIN					|	0				||	true
+			-MIN				|	0				||	true
+			NINF				|	PINF			||	false
+			PINF				|	NINF			||	false
+			NAN					|	0				||	false
+			MAX					|	PINF			||	false
+			-MAX				|	NINF			||	false
+			42.0 as BigDecimal	|	42 as Long		||	true
+	}
+
+	def "greaterThan"() {
+		given:
+			Matcher m = NumberMatchers.greaterThan(value as Number)
+		expect:
+			m.matches(item as Number) == result
+		where:
+			item				|	value			||	result
+			0					|	0				||	false
+			MIN					|	0				||	false
+			-MIN				|	0				||	false
+			NINF				|	PINF			||	false
+			PINF				|	NINF			||	true
+			NAN					|	0				||	true
+			MAX					|	PINF			||	false
+			PINF				|	MAX				||	true
+			-MAX				|	NINF			||	true
+			MAX					|	MIN				||	true
+			42.0 as BigDecimal	|	41 as Long		||	true
+			41.0 as Float		|	42 as Short		||	false
+			42.0 as Double		|	42 as Byte		||	false
+	}
+
+	def "lowerThan"() {
+		given:
+			Matcher m = NumberMatchers.lowerThan(value as Number)
+		expect:
+			m.matches(item as Number) == result
+		where:
+			item				|	value			||	result
+			0					|	0				||	false
+			MIN					|	0				||	false
+			-MIN				|	0				||	false
+			NINF				|	PINF			||	true
+			PINF				|	NINF			||	false
+			NAN					|	0				||	false
+			MAX					|	PINF			||	true
+			PINF				|	MAX				||	false
+			-MAX				|	NINF			||	false
+			MAX					|	MIN				||	false
+			42.0 as BigDecimal	|	41 as Long		||	false
+			41.0 as Float		|	42 as Short		||	true
+			42.0 as Double		|	42 as Byte		||	false
+	}
+
+	def "greaterThanOrEqual"() {
+		given:
+			Matcher m = NumberMatchers.greaterThanOrEqual(value as Number)
+		expect:
+			m.matches(item as Number) == result
+		where:
+			item				|	value			||	result
+			0					|	0				||	true
+			MIN					|	0				||	true
+			-MIN				|	0				||	true
+			NINF				|	PINF			||	false
+			PINF				|	NINF			||	true
+			NAN					|	0				||	true
+			MAX					|	PINF			||	false
+			PINF				|	MAX				||	true
+			-MAX				|	NINF			||	true
+			MAX					|	MIN				||	true
+			42.0 as BigDecimal	|	41 as Long		||	true
+			41.0 as Float		|	42 as Short		||	false
+			42.0 as Double		|	42 as Byte		||	true
+	}
+
+	def "lowerThanOrEqual"() {
+		given:
+			Matcher m = NumberMatchers.lowerThanOrEqual(value as Number)
+		expect:
+			m.matches(item as Number) == result
+		where:
+			item				|	value			||	result
+			0					|	0				||	true
+			MIN					|	0				||	true
+			-MIN				|	0				||	true
+			NINF				|	PINF			||	true
+			PINF				|	NINF			||	false
+			NAN					|	0				||	false
+			MAX					|	PINF			||	true
+			PINF				|	MAX				||	false
+			-MAX				|	NINF			||	false
+			MAX					|	MIN				||	false
+			42.0 as BigDecimal	|	41 as Long		||	false
+			41.0 as Float		|	42 as Short		||	true
+			42.0 as Double		|	42 as Byte		||	true
+	}
+
+	def "between"() {
+		given:
+			Matcher m = NumberMatchers.between(a as Number, b as Number)
+		expect:
+			m.matches(item as Number) == result
+		where:
+			item				|	a			|	b			||	result
+			0					|	0			|	0			||	false
+			0					|	0			|	1			||	false
+			0					|	-1			|	0			||	false
+			0					|	-1			|	1			||	true
+			0					|	1			|	10			||	false
+			0					|	MIN			|	MAX			||	false
+			0					|	-MAX		|	MIN			||	false
+			0					|	-MAX		|	MAX			||	true
+			0					|	NINF		|	PINF		||	true
+			0					|	-1			|	NAN			||	true
+			PINF				|	MAX			|	NAN			||	true
+			-MAX				|	NINF		|	0			||	true
+	}
+
+	def "betweenOrEqual"() {
+		given:
+			Matcher m = NumberMatchers.betweenOrEqual(a as Number, b as Number)
+		expect:
+			m.matches(item as Number) == result
+		where:
+			item				|	a			|	b			||	result
+			0					|	0			|	0			||	true
+			0					|	0			|	1			||	true
+			0					|	-1			|	0			||	true
+			0					|	-1			|	1			||	true
+			0					|	1			|	10			||	false
+			0					|	MIN			|	MAX			||	true
+			0					|	-MAX		|	MIN			||	true
+			0					|	-MAX		|	MAX			||	true
+			0					|	NINF		|	PINF		||	true
+			0					|	-1			|	NAN			||	true
+			PINF				|	MAX			|	NAN			||	true
+			-MAX				|	NINF		|	0			||	true
+	}
+}

--- a/src/test/groovy/org/whaka/asserts/matcher/FunctionalMatcherTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/matcher/FunctionalMatcherTest.groovy
@@ -1,0 +1,116 @@
+package org.whaka.asserts.matcher
+
+import java.util.function.Consumer
+import java.util.function.Predicate
+
+import org.hamcrest.Description
+
+import spock.lang.Specification
+
+class FunctionalMatcherTest extends Specification {
+
+	def "construction"() {
+		given:
+			Predicate predicate = Mock()
+			Consumer describer = Mock()
+		when:
+			def m = new FunctionalMatcher(type, predicate, describer)
+		then:
+			0 * predicate.test(_)
+			0 * describer.accept(_)
+		and:
+			m.getType().is(type)
+			m.getPredicate().is(predicate)
+			m.getDescriber().is(describer)
+		where:
+			type << [String, Number, Boolean, FunctionalMatcherTest, Object, Void]
+	}
+
+	def "construction with string"() {
+		given:
+			Predicate predicate = Mock()
+			Description description = Mock()
+
+		when:
+			def m = new FunctionalMatcher(String, predicate, "test description")
+		then:
+			0 * predicate.test(_)
+		and:
+			m.getType().is(String)
+			m.getPredicate().is(predicate)
+
+		when:
+			m.describeTo(description)
+		then:
+			1 * description.appendText("test description")
+	}
+
+	def "matches: wrong instance"() {
+		given:
+			Predicate predicate = Mock()
+			Consumer describer = Mock()
+			def m = new FunctionalMatcher(type, predicate, describer)
+		when:
+			def res = m.matches(wrongInstance)
+		then:
+			0 * predicate.test(_)
+			0 * describer.accept(_)
+		and:
+			res == false
+		where:
+			type			|	wrongInstance
+			String			|	12
+			String			|	false
+			Integer			|	15.0
+			Integer			|	"qwe"
+			Boolean			|	42
+			Boolean			|	"rty"
+			Number			|	true
+			Number			|	"qaz"
+	}
+
+	def "matches: right instance"() {
+		given:
+			Predicate predicate = Mock()
+			Consumer describer = Mock()
+			def m = new FunctionalMatcher(String, predicate, describer)
+		when:
+			def res = m.matches("item")
+		then:
+			1 * predicate.test("item") >> result
+			0 * describer.accept(_)
+		and:
+			res == result
+		where:
+			result << [true, false]
+	}
+
+	def "matches: null is not tested for type"() {
+		given:
+			Predicate predicate = Mock()
+			Consumer describer = Mock()
+			def m = new FunctionalMatcher(type, predicate, describer)
+		when:
+			def res = m.matches(null as Object)
+		then:
+			1 * predicate.test(null) >> true
+			0 * describer.accept(_)
+		and:
+			res == true
+		where:
+			type << [String, Number, Boolean, FunctionalMatcherTest, Object, Void]
+	}
+
+	def "describeTo"() {
+		given:
+			Predicate predicate = Mock()
+			Consumer describer = Mock()
+			Description description = Mock()
+			def m = new FunctionalMatcher(String, predicate, describer)
+		when:
+			m.describeTo(description)
+		then:
+			0 * predicate.test(_)
+			1 * describer.accept(description) >> {}
+	}
+}


### PR DESCRIPTION
- Resolve #44 [Assert] Create "equalToNumber" matcher
- Resolve #45 [Assert] Create "number,finite,zero,positive,negative" matchers
- Resolve #47 [Assert] Create "greaterThan,lowerThan,greaterThanOrEqual,lowerThanOrEqual" matchers
- Resolve #48 [Assert] Create "between,betweenOrEqual" matchers

All custom `DoubleMath` matchers were implemented under this branch, for a single new "matcher" class was required, and the whole diversity of different matchers were implemented as factory methods in the `NumberMatchers`, for most of the difference was in the arguments to the same matcher class.
# 
1. `FunctionalMatcher` is implemented
2. All factory methods in the `NumberMatchers` are implemented.
