### PR TITLE
Resolve #32 [Assert] Create "EqualTo" matcher with a ComparisonPerformer

### DIFF
--- a/src/main/java/org/whaka/asserts/AssertBuilder.java
+++ b/src/main/java/org/whaka/asserts/AssertBuilder.java
@@ -53,6 +53,7 @@ public class AssertBuilder {
 	}
 
 	public AssertBuilder addResult(AssertResult result) {
+		Objects.requireNonNull(result, "Assert result cannot be null!");
 		assertResults.add(result);
 		return this;
 	}
@@ -101,15 +102,18 @@ public class AssertBuilder {
 	 * @see #checkThat(Object, Matcher, String)
 	 */
 	public <T> AssertBuilder checkThat(T item, Matcher<T> matcher, String message, Throwable cause) {
-		if (!matcher.matches(item))
-			addResult(cresteResult(item, matcher, message, cause));
+		AssertResult result = cresteResult(item, matcher, message, cause);
+		if (result != null)
+			addResult(result);
 		return this;
 	}
 	
 	private static <T> AssertResult cresteResult(T item, Matcher<T> matcher, String message, Throwable cause) {
 		if (matcher instanceof ResultProvidingMatcher)
-			return ((ResultProvidingMatcher<T>)matcher).createAssertResult(item, message, cause);
-		return createDefaultResult(item, matcher, message, cause);
+			return ((ResultProvidingMatcher<T>)matcher).matches(item, message, cause);
+		if (!matcher.matches(item))
+			return createDefaultResult(item, matcher, message, cause);
+		return null;
 	}
 	
 	private static <T> AssertResult createDefaultResult(T item, Matcher<T> matcher, String message, Throwable cause) {

--- a/src/main/java/org/whaka/asserts/AssertBuilder.java
+++ b/src/main/java/org/whaka/asserts/AssertBuilder.java
@@ -1,5 +1,7 @@
 package org.whaka.asserts;
 
+import static java.util.Optional.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -102,13 +104,11 @@ public class AssertBuilder {
 	 * @see #checkThat(Object, Matcher, String)
 	 */
 	public <T> AssertBuilder checkThat(T item, Matcher<T> matcher, String message, Throwable cause) {
-		AssertResult result = cresteResult(item, matcher, message, cause);
-		if (result != null)
-			addResult(result);
+		ofNullable(performCheck(item, matcher, message, cause)).ifPresent(this::addResult);
 		return this;
 	}
 	
-	private static <T> AssertResult cresteResult(T item, Matcher<T> matcher, String message, Throwable cause) {
+	private static <T> AssertResult performCheck(T item, Matcher<T> matcher, String message, Throwable cause) {
 		if (matcher instanceof ResultProvidingMatcher)
 			return ((ResultProvidingMatcher<T>)matcher).matches(item, message, cause);
 		if (!matcher.matches(item))

--- a/src/main/java/org/whaka/asserts/AssertBuilder.java
+++ b/src/main/java/org/whaka/asserts/AssertBuilder.java
@@ -1,7 +1,5 @@
 package org.whaka.asserts;
 
-import static java.util.Optional.*;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -104,16 +102,16 @@ public class AssertBuilder {
 	 * @see #checkThat(Object, Matcher, String)
 	 */
 	public <T> AssertBuilder checkThat(T item, Matcher<T> matcher, String message, Throwable cause) {
-		ofNullable(performCheck(item, matcher, message, cause)).ifPresent(this::addResult);
+		performCheck(item, matcher, message, cause).ifPresent(this::addResult);
 		return this;
 	}
 	
-	private static <T> AssertResult performCheck(T item, Matcher<T> matcher, String message, Throwable cause) {
+	private static <T> Optional<? extends AssertResult> performCheck(T item, Matcher<T> matcher, String message, Throwable cause) {
 		if (matcher instanceof ResultProvidingMatcher)
 			return ((ResultProvidingMatcher<T>)matcher).matches(item, message, cause);
 		if (!matcher.matches(item))
-			return createDefaultResult(item, matcher, message, cause);
-		return null;
+			return Optional.of(createDefaultResult(item, matcher, message, cause));
+		return Optional.empty();
 	}
 	
 	private static <T> AssertResult createDefaultResult(T item, Matcher<T> matcher, String message, Throwable cause) {

--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -4,19 +4,61 @@ import java.util.regex.Pattern;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
+import org.whaka.asserts.matcher.ComparisonMatcher;
 import org.whaka.asserts.matcher.ConsistencyMatcher;
 import org.whaka.asserts.matcher.RegexpMatcher;
 import org.whaka.asserts.matcher.ThrowableMatcher;
+import org.whaka.util.reflection.comparison.ComparisonPerformer;
+import org.whaka.util.reflection.comparison.ComparisonPerformers;
 
 
 /**
- * Class provides static factory methods for custom Hamcrest matchers provided by the librabry.
+ * Class provides static factory methods for custom Hamcrest matchers provided by the library.
  * 
  * @see NumberMatchers
  */
 public final class UberMatchers {
 
 	private UberMatchers() {
+	}
+	
+	/**
+	 * Create a matcher that will check that tested item and specified value are equal
+	 * according to the specified {@link ComparisonPerformer}.
+	 * 
+	 * @see #deeplyEqualTo(Object)
+	 * @see #reflectivelyEqualTo(Object)
+	 * @see ComparisonMatcher
+	 * @see ComparisonPerformers
+	 */
+	public static <T> Matcher<T> comparativelyEqualTo(T item, ComparisonPerformer<? super T> performer) {
+		return new ComparisonMatcher<>(item, performer);
+	}
+	
+	/**
+	 * Create a matcher that will check that tested item and specified value are equal
+	 * according to the {@link ComparisonPerformers#DEEP_EQUALS} performer.
+	 * 
+	 * @see #comparativelyEqualTo(Object, ComparisonPerformer)
+	 * @see #reflectivelyEqualTo(Object)
+	 * @see ComparisonMatcher
+	 * @see ComparisonPerformers
+	 */
+	public static <T> Matcher<T> deeplyEqualTo(T item) {
+		return comparativelyEqualTo(item, ComparisonPerformers.DEEP_EQUALS);
+	}
+	
+	/**
+	 * Create a matcher that will check that tested item and specified value are equal
+	 * according to the {@link ComparisonPerformers#REFLECTIVE_EQUALS} performer.
+	 * 
+	 * @see #comparativelyEqualTo(Object, ComparisonPerformer)
+	 * @see #deeplyEqualTo(Object)
+	 * @see ComparisonMatcher
+	 * @see ComparisonPerformers
+	 */
+	public static <T> Matcher<T> reflectivelyEqualTo(T item) {
+		return comparativelyEqualTo(item, ComparisonPerformers.REFLECTIVE_EQUALS);
 	}
 	
 	/**

--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -31,7 +31,7 @@ public final class UberMatchers {
 	 * @see ComparisonMatcher
 	 * @see ComparisonPerformers
 	 */
-	public static <T> Matcher<T> comparativelyEqualTo(T item, ComparisonPerformer<? super T> performer) {
+	public static <T> Matcher<T> equalTo(T item, ComparisonPerformer<? super T> performer) {
 		return new ComparisonMatcher<>(item, performer);
 	}
 	
@@ -39,26 +39,26 @@ public final class UberMatchers {
 	 * Create a matcher that will check that tested item and specified value are equal
 	 * according to the {@link ComparisonPerformers#DEEP_EQUALS} performer.
 	 * 
-	 * @see #comparativelyEqualTo(Object, ComparisonPerformer)
+	 * @see #equalTo(Object, ComparisonPerformer)
 	 * @see #reflectivelyEqualTo(Object)
 	 * @see ComparisonMatcher
 	 * @see ComparisonPerformers
 	 */
 	public static <T> Matcher<T> deeplyEqualTo(T item) {
-		return comparativelyEqualTo(item, ComparisonPerformers.DEEP_EQUALS);
+		return equalTo(item, ComparisonPerformers.DEEP_EQUALS);
 	}
 	
 	/**
 	 * Create a matcher that will check that tested item and specified value are equal
 	 * according to the {@link ComparisonPerformers#REFLECTIVE_EQUALS} performer.
 	 * 
-	 * @see #comparativelyEqualTo(Object, ComparisonPerformer)
+	 * @see #equalTo(Object, ComparisonPerformer)
 	 * @see #deeplyEqualTo(Object)
 	 * @see ComparisonMatcher
 	 * @see ComparisonPerformers
 	 */
 	public static <T> Matcher<T> reflectivelyEqualTo(T item) {
-		return comparativelyEqualTo(item, ComparisonPerformers.REFLECTIVE_EQUALS);
+		return equalTo(item, ComparisonPerformers.REFLECTIVE_EQUALS);
 	}
 	
 	/**

--- a/src/main/java/org/whaka/asserts/matcher/ComparisonMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ComparisonMatcher.java
@@ -1,0 +1,45 @@
+package org.whaka.asserts.matcher;
+
+import java.util.Objects;
+
+import org.hamcrest.Description;
+import org.whaka.asserts.AssertResult;
+import org.whaka.asserts.ComparisonAssertResult;
+import org.whaka.util.reflection.comparison.ComparisonPerformer;
+import org.whaka.util.reflection.comparison.ComparisonResult;
+
+public class ComparisonMatcher<T> extends ResultProvidingMatcher<T> {
+
+	private final T value;
+	private final ComparisonPerformer<? super T> comparisonPerformer;
+	
+	public ComparisonMatcher(T value, ComparisonPerformer<? super T> comparisonPerformer) {
+		this.value = value;
+		this.comparisonPerformer = Objects.requireNonNull(comparisonPerformer, "Comparison performer cannot be null!");
+	}
+
+	public T getValue() {
+		return value;
+	}
+
+	public ComparisonPerformer<? super T> getComparisonPerformer() {
+		return comparisonPerformer;
+	}
+
+	@Override
+	public AssertResult matches(T item, String message, Throwable cause) {
+		ComparisonResult comparisonResult = getComparisonPerformer().compare(item, getValue());
+		if (comparisonResult.isSuccess())
+			return null;
+		AssertResult result = ComparisonAssertResult.createWithCause(comparisonResult);
+		if (result.getCause() == null)
+			result.setCause(cause);
+		return result;
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("equal to ").appendValue(getValue())
+			.appendText(" according to " + getComparisonPerformer());
+	}
+}

--- a/src/main/java/org/whaka/asserts/matcher/ComparisonMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ComparisonMatcher.java
@@ -3,7 +3,6 @@ package org.whaka.asserts.matcher;
 import java.util.Objects;
 
 import org.hamcrest.Description;
-import org.whaka.asserts.AssertResult;
 import org.whaka.asserts.ComparisonAssertResult;
 import org.whaka.util.reflection.comparison.ComparisonPerformer;
 import org.whaka.util.reflection.comparison.ComparisonResult;
@@ -27,11 +26,11 @@ public class ComparisonMatcher<T> extends ResultProvidingMatcher<T> {
 	}
 
 	@Override
-	public AssertResult matches(T item, String message, Throwable cause) {
+	public ComparisonAssertResult matches(T item, String message, Throwable cause) {
 		ComparisonResult comparisonResult = getComparisonPerformer().compare(item, getValue());
 		if (comparisonResult.isSuccess())
 			return null;
-		AssertResult result = ComparisonAssertResult.createWithCause(comparisonResult);
+		ComparisonAssertResult result = ComparisonAssertResult.createWithCause(comparisonResult, message);
 		if (result.getCause() == null)
 			result.setCause(cause);
 		return result;

--- a/src/main/java/org/whaka/asserts/matcher/ComparisonMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ComparisonMatcher.java
@@ -1,6 +1,7 @@
 package org.whaka.asserts.matcher;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -37,14 +38,14 @@ public class ComparisonMatcher<T> extends ResultProvidingMatcher<T> {
 	}
 
 	@Override
-	public ComparisonAssertResult matches(T item, String message, Throwable cause) {
+	public Optional<ComparisonAssertResult> matches(T item, String message, Throwable cause) {
 		ComparisonResult comparisonResult = getComparisonPerformer().compare(item, getValue());
 		if (comparisonResult.isSuccess())
-			return null;
+			return Optional.empty();
 		ComparisonAssertResult result = ComparisonAssertResult.createWithCause(comparisonResult, message);
 		if (result.getCause() == null)
 			result.setCause(cause);
-		return result;
+		return Optional.of(result);
 	}
 	
 	@Override

--- a/src/main/java/org/whaka/asserts/matcher/ComparisonMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ComparisonMatcher.java
@@ -3,10 +3,21 @@ package org.whaka.asserts.matcher;
 import java.util.Objects;
 
 import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.whaka.asserts.ComparisonAssertResult;
 import org.whaka.util.reflection.comparison.ComparisonPerformer;
+import org.whaka.util.reflection.comparison.ComparisonPerformers;
 import org.whaka.util.reflection.comparison.ComparisonResult;
 
+/**
+ * <p>{@link Matcher} implementation that allows to perform object comparison using {@link ComparisonPerformer}
+ * as delegate.
+ * 
+ * <p><b>Note:</b> matcher able to provide specific {@link ComparisonAssertResult} containing more
+ * information about performed comparison.
+ * 
+ * @see ComparisonPerformers
+ */
 public class ComparisonMatcher<T> extends ResultProvidingMatcher<T> {
 
 	private final T value;

--- a/src/main/java/org/whaka/asserts/matcher/ResultProvidingMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ResultProvidingMatcher.java
@@ -1,5 +1,7 @@
 package org.whaka.asserts.matcher;
 
+import java.util.Optional;
+
 import org.hamcrest.BaseMatcher;
 import org.whaka.asserts.AssertResult;
 
@@ -8,12 +10,12 @@ public abstract class ResultProvidingMatcher<T> extends BaseMatcher<T> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public final boolean matches(Object item) {
-		return matches((T) item, null, null) == null;
+		return !matches((T) item, null, null).isPresent();
 	}
 	
 	/**
-	 * This method should return <code>null</code> in case matcher successfully matched specified item.
-	 * Otherwise it should return an instance of the {@link AssertResult}.
+	 * This method should return {@link Optional#empty()} in case matcher successfully matched specified item.
+	 * Otherwise it should return an optional containing an instance of the {@link AssertResult}.
 	 */
-	public abstract AssertResult matches(T item, String message, Throwable cause);
+	public abstract Optional<? extends AssertResult> matches(T item, String message, Throwable cause);
 }

--- a/src/main/java/org/whaka/asserts/matcher/ResultProvidingMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ResultProvidingMatcher.java
@@ -5,5 +5,15 @@ import org.whaka.asserts.AssertResult;
 
 public abstract class ResultProvidingMatcher<T> extends BaseMatcher<T> {
 
-	public abstract AssertResult createAssertResult(T item, String message, Throwable cause);
+	@Override
+	@SuppressWarnings("unchecked")
+	public final boolean matches(Object item) {
+		return matches((T) item, null, null) == null;
+	}
+	
+	/**
+	 * This method should return <code>null</code> in case matcher successfully matched specified item.
+	 * Otherwise it should return an instance of the {@link AssertResult}.
+	 */
+	public abstract AssertResult matches(T item, String message, Throwable cause);
 }

--- a/src/main/java/org/whaka/asserts/matcher/ThrowableMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ThrowableMatcher.java
@@ -2,6 +2,8 @@ package org.whaka.asserts.matcher;
 
 import static java.util.Optional.*;
 
+import java.util.Optional;
+
 import org.hamcrest.Description;
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
@@ -35,13 +37,13 @@ public class ThrowableMatcher extends ResultProvidingMatcher<Throwable> {
 	}
 	
 	@Override
-	public AssertResult matches(Throwable item, String message, Throwable cause) {
+	public Optional<AssertResult> matches(Throwable item, String message, Throwable cause) {
 		if (getExpectedType() == null ? item == null : getExpectedType().isInstance(item))
-			return null;
+			return Optional.empty();
 		Class<?> actual = ofNullable(item).map(Object::getClass).orElse(null);
 		if (cause == null)
 			cause = item;
-		return new AssertResult(actual, getExpectedMessage(), message, cause);
+		return Optional.of(new AssertResult(actual, getExpectedMessage(), message, cause));
 	}
 	
 	@Override

--- a/src/main/java/org/whaka/asserts/matcher/ThrowableMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/ThrowableMatcher.java
@@ -35,10 +35,15 @@ public class ThrowableMatcher extends ResultProvidingMatcher<Throwable> {
 	}
 	
 	@Override
-	public boolean matches(Object item) {
-		return getExpectedType() == null ? item == null : getExpectedType().isInstance(item);
+	public AssertResult matches(Throwable item, String message, Throwable cause) {
+		if (getExpectedType() == null ? item == null : getExpectedType().isInstance(item))
+			return null;
+		Class<?> actual = ofNullable(item).map(Object::getClass).orElse(null);
+		if (cause == null)
+			cause = item;
+		return new AssertResult(actual, getExpectedMessage(), message, cause);
 	}
-
+	
 	@Override
 	public void describeTo(Description description) {
 		description.appendText(getExpectedMessage());
@@ -47,14 +52,6 @@ public class ThrowableMatcher extends ResultProvidingMatcher<Throwable> {
 	private String getExpectedMessage() {
 		return getExpectedType() == null ? "no exception"
 				: "instance of " + getExpectedType().getCanonicalName();
-	}
-	
-	@Override
-	public AssertResult createAssertResult(Throwable item, String message, Throwable cause) {
-		Class<?> actual = ofNullable(item).map(Object::getClass).orElse(null);
-		if (cause == null)
-			cause = item;
-		return new AssertResult(actual, getExpectedMessage(), message, cause);
 	}
 	
 	/**

--- a/src/test/groovy/org/whaka/asserts/AssertBuilderTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/AssertBuilderTest.groovy
@@ -246,6 +246,22 @@ class AssertBuilderTest extends Specification {
 			res.getCause() == null
 	}
 
+	def "checkThat for ResultProvidingMatcher - success"() {
+		given:
+			ResultProvidingMatcher matcher = Mock()
+			AssertBuilder builder = new AssertBuilder()
+			Throwable cause = Mock()
+
+		when:
+			builder.checkThat(42, matcher, "msg", cause)
+		then:
+			1 * matcher.matches(42, "msg", cause) >> null
+		and:
+			0 * matcher.describeTo(_)
+		and:
+			builder.getAssertResults().size() == 0
+	}
+
 	def "checkThat for ResultProvidingMatcher - custom result"() {
 		given:
 			ResultProvidingMatcher matcher = Mock()
@@ -256,11 +272,9 @@ class AssertBuilderTest extends Specification {
 		when:
 			builder.checkThat(42, matcher, "msg", cause)
 		then:
-			1 * matcher.matches(42) >> false
+			1 * matcher.matches(42, "msg", cause) >> result
 		and:
 			0 * matcher.describeTo(_)
-		and:
-			1 * matcher.createAssertResult(42, "msg", cause) >> result
 		and:
 			builder.getAssertResults().size() == 1
 			def res = builder.getAssertResults()[0]

--- a/src/test/groovy/org/whaka/asserts/AssertBuilderTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/AssertBuilderTest.groovy
@@ -255,7 +255,7 @@ class AssertBuilderTest extends Specification {
 		when:
 			builder.checkThat(42, matcher, "msg", cause)
 		then:
-			1 * matcher.matches(42, "msg", cause) >> null
+			1 * matcher.matches(42, "msg", cause) >> Optional.empty()
 		and:
 			0 * matcher.describeTo(_)
 		and:
@@ -272,7 +272,7 @@ class AssertBuilderTest extends Specification {
 		when:
 			builder.checkThat(42, matcher, "msg", cause)
 		then:
-			1 * matcher.matches(42, "msg", cause) >> result
+			1 * matcher.matches(42, "msg", cause) >> Optional.of(result)
 		and:
 			0 * matcher.describeTo(_)
 		and:

--- a/src/test/groovy/org/whaka/asserts/matcher/ComparisonMatcherTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/matcher/ComparisonMatcherTest.groovy
@@ -30,7 +30,7 @@ class ComparisonMatcherTest extends Specification {
 			ComparisonResult comparisonResult = new ComparisonResult(null, null, null, true)
 			def m = new ComparisonMatcher("value", performer)
 		when:
-			ComparisonAssertResult res = m.matches("item", "msg " + cause, cause)
+			ComparisonAssertResult res = m.matches("item", "msg " + cause, cause).orElse(null)
 		then:
 			1 * performer.compare("item", "value") >> comparisonResult
 		and:
@@ -45,7 +45,7 @@ class ComparisonMatcherTest extends Specification {
 			ComparisonResult comparisonResult = new ComparisonResult("item", "value", performer, false)
 			def m = new ComparisonMatcher("value", performer)
 		when:
-			ComparisonAssertResult res = m.matches("item", "msg " + cause, cause)
+			ComparisonAssertResult res = m.matches("item", "msg " + cause, cause).get()
 		then:
 			1 * performer.compare("item", "value") >> comparisonResult
 		and:
@@ -65,7 +65,7 @@ class ComparisonMatcherTest extends Specification {
 			ComparisonResult comparisonResult = new ComparisonFail(null, null, null, comparisonCause)
 			def m = new ComparisonMatcher("value", performer)
 		when:
-			ComparisonAssertResult res = m.matches("item", "msg " + cause, cause)
+			ComparisonAssertResult res = m.matches("item", "msg " + cause, cause).get()
 		then:
 			1 * performer.compare("item", "value") >> comparisonResult
 		and:

--- a/src/test/groovy/org/whaka/asserts/matcher/ComparisonMatcherTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/matcher/ComparisonMatcherTest.groovy
@@ -1,0 +1,78 @@
+package org.whaka.asserts.matcher
+
+import org.whaka.TestData
+import org.whaka.asserts.ComparisonAssertResult
+import org.whaka.util.reflection.comparison.ComparisonFail
+import org.whaka.util.reflection.comparison.ComparisonPerformer
+import org.whaka.util.reflection.comparison.ComparisonResult
+
+import spock.lang.Specification
+
+class ComparisonMatcherTest extends Specification {
+
+	def "construction"() {
+		given:
+			ComparisonPerformer performer = Mock()
+		when:
+			def m = new ComparisonMatcher(value, performer)
+		then:
+			0 * performer.compare(_, _)
+		and:
+			m.getValue().is(value)
+			m.getComparisonPerformer().is(performer)
+		where:
+			value << TestData.variousObjects()
+	}
+
+	def "matches: success"() {
+		given:
+			ComparisonPerformer performer = Mock()
+			ComparisonResult comparisonResult = new ComparisonResult(null, null, null, true)
+			def m = new ComparisonMatcher("value", performer)
+		when:
+			ComparisonAssertResult res = m.matches("item", "msg " + cause, cause)
+		then:
+			1 * performer.compare("item", "value") >> comparisonResult
+		and:
+			res == null
+		where:
+			cause << TestData.variousCauses()
+	}
+
+	def "matches: fail"() {
+		given:
+			ComparisonPerformer performer = Mock()
+			ComparisonResult comparisonResult = new ComparisonResult("item", "value", performer, false)
+			def m = new ComparisonMatcher("value", performer)
+		when:
+			ComparisonAssertResult res = m.matches("item", "msg " + cause, cause)
+		then:
+			1 * performer.compare("item", "value") >> comparisonResult
+		and:
+			res.getComparisonResult().is(comparisonResult)
+			res.getActual() == "item"
+			res.getExpected() == "value"
+			res.getMessage() == "msg $cause"
+			res.getCause() == cause
+		where:
+			cause << TestData.variousCauses()
+	}
+
+	def "matches: if comparison fail happened - specified cause is ignored"() {
+		given:
+			ComparisonPerformer performer = Mock()
+			def comparisonCause = new IOException("stahp!")
+			ComparisonResult comparisonResult = new ComparisonFail(null, null, null, comparisonCause)
+			def m = new ComparisonMatcher("value", performer)
+		when:
+			ComparisonAssertResult res = m.matches("item", "msg " + cause, cause)
+		then:
+			1 * performer.compare("item", "value") >> comparisonResult
+		and:
+			res.getComparisonResult().is(comparisonResult)
+			res.getMessage() == "msg $cause"
+			res.getCause() == comparisonCause
+		where:
+			cause << TestData.variousCauses()
+	}
+}

--- a/src/test/groovy/org/whaka/asserts/matcher/ThrowableMatcherTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/matcher/ThrowableMatcherTest.groovy
@@ -1,6 +1,7 @@
 package org.whaka.asserts.matcher
 
 import org.whaka.TestData
+import org.whaka.asserts.AssertResult
 
 import spock.lang.Specification
 
@@ -55,12 +56,12 @@ class ThrowableMatcherTest extends Specification {
 			cause << TestData.variousCauses()
 	}
 
-	def "create result"() {
+	def "matches with result"() {
 		given:
 			def m1 = ThrowableMatcher.throwableOfType(RuntimeException)
-			def item = new RuntimeException("qwe")
+			def item = new IOException("qwe")
 		when:
-			def res = m1.createAssertResult(item, "msg " + cause, cause)
+			AssertResult res = m1.matches(item, "msg " + cause, cause)
 		then:
 			res.getActual() == item?.getClass()
 			res.getExpected() == "instance of ${RuntimeException.class.getCanonicalName()}"

--- a/src/test/groovy/org/whaka/asserts/matcher/ThrowableMatcherTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/matcher/ThrowableMatcherTest.groovy
@@ -61,7 +61,7 @@ class ThrowableMatcherTest extends Specification {
 			def m1 = ThrowableMatcher.throwableOfType(RuntimeException)
 			def item = new IOException("qwe")
 		when:
-			AssertResult res = m1.matches(item, "msg " + cause, cause)
+			AssertResult res = m1.matches(item, "msg " + cause, cause).get()
 		then:
 			res.getActual() == item?.getClass()
 			res.getExpected() == "instance of ${RuntimeException.class.getCanonicalName()}"


### PR DESCRIPTION
1. `ResultProvidingMatcher` refactored so it would require a single call to perform match **and** produce a custom result.
2. `AssertBuilder#checkThat` is refactored according to new `ResultProvidingMatcher`
3. ComparisonMatcher implemented
