### PR TITLE
Resolve #38 [Assert] Create "hasItem" matcher with a BiPredicate

### DIFF
--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -95,7 +95,11 @@ public final class UberMatchers {
 	public static Matcher<Throwable> notExpected() {
 		return ThrowableMatcher.notExpected();
 	}
-
+	
+	/**
+	 * Create a matcher that will check that a collection contains the specified item.
+	 * Specified predicate is used to check elements equality.
+	 */
 	public static <T> Matcher<Collection<? extends T>> hasItem(T item, BiPredicate<T, T> matcher) {
 		Objects.requireNonNull(matcher, "Predicate cannot be null!");
 		return new FunctionalMatcher<Collection<? extends T>>(

--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -1,12 +1,18 @@
 package org.whaka.asserts;
 
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.BiPredicate;
 import java.util.regex.Pattern;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.whaka.asserts.matcher.ConsistencyMatcher;
+import org.whaka.asserts.matcher.FunctionalMatcher;
 import org.whaka.asserts.matcher.RegexpMatcher;
 import org.whaka.asserts.matcher.ThrowableMatcher;
+import org.whaka.util.UberCollections;
+import org.whaka.util.reflection.UberClasses;
 
 
 /**
@@ -88,5 +94,13 @@ public final class UberMatchers {
 	 */
 	public static Matcher<Throwable> notExpected() {
 		return ThrowableMatcher.notExpected();
+	}
+
+	public static <T> Matcher<Collection<? extends T>> hasItem(T item, BiPredicate<T, T> matcher) {
+		Objects.requireNonNull(matcher, "Predicate cannot be null!");
+		return new FunctionalMatcher<Collection<? extends T>>(
+				UberClasses.cast(Collection.class),
+				c -> UberCollections.contains(c, item, matcher),
+				d -> d.appendText("has item ").appendValue(item).appendText(" with a predicate"));
 	}
 }

--- a/src/test/groovy/org/whaka/asserts/UberMatchersTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/UberMatchersTest.groovy
@@ -1,0 +1,64 @@
+package org.whaka.asserts
+
+import java.util.function.BiPredicate
+
+import org.hamcrest.Matcher
+
+import spock.lang.Specification
+
+class UberMatchersTest extends Specification {
+
+	def "hasItem with predicate: basics"() {
+		given:
+			BiPredicate predicate = Mock()
+			Matcher m = UberMatchers.hasItem("item", predicate)
+			List<String> values = ["qwe", "rty", "qaz", "pop"]
+		when:
+			def res = m.matches(values)
+		then:
+			1 * predicate.test("qwe", "item") >> false
+		and:
+			1 * predicate.test("rty", "item") >> false
+		and:
+			1 * predicate.test("qaz", "item") >> true
+		and:
+			0 * predicate.test(_, _)
+		and:
+			res == true
+	}
+
+	def "hasItem with predicate: examples"() {
+		given:
+			Matcher m = UberMatchers.hasItem(item, predicate)
+		expect:
+			m.matches(values as List) == result
+		where:
+			values				|	item		|	predicate				||	result
+			[]					|	3			|	Objects.&equals			||	false
+			[]					|	3			|	{a,b -> true}			||	false
+			[1,2]				|	3			|	Objects.&equals			||	false
+			[1,2]				|	3			|	{a,b -> true}			||	true
+			[1,2,3]				|	3			|	Objects.&equals			||	true
+			[1,2,3]				|	3			|	{a,b -> false}			||	false
+			[]					|	null		|	Objects.&equals			||	false
+			[null]				|	null		|	Objects.&equals			||	true
+			[null, null]		|	null		|	Objects.&equals			||	true
+	}
+
+	def "hasItem with predicate: NPE"() {
+
+		when:
+			UberMatchers.hasItem(null, Mock(BiPredicate))
+		then:
+			notThrown()
+
+		when:
+			UberMatchers.hasItem(42, null)
+		then:
+			thrown(NullPointerException)
+	}
+
+	private static int[] arr(int[] arr) {
+		return arr
+	}
+}

--- a/src/test/groovy/org/whaka/asserts/UberMatchersTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/UberMatchersTest.groovy
@@ -47,13 +47,18 @@ class UberMatchersTest extends Specification {
 
 	def "hasItem with predicate: NPE"() {
 
-		when:
+		when: "item is null, but predicate is valid"
 			UberMatchers.hasItem(null, Mock(BiPredicate))
-		then:
+		then: "nothing is thrown - null value is searched"
 			notThrown()
 
-		when:
+		when: "predicate is null"
 			UberMatchers.hasItem(42, null)
+		then:
+			thrown(NullPointerException)
+
+		when: "properly created matcher is called upon null value as a collection"
+			UberMatchers.hasItem(42, {a,b->true}).matches(null as Collection)
 		then:
 			thrown(NullPointerException)
 	}


### PR DESCRIPTION
Method `UberMatchers.hasItem(T, BiPredicate<T,T>)` is implemented.
Functional matcher is used to implement new functionality.
