### PR TITLE
#42 [Assert] Create "hasAnyItem" matcher with BiPredicate

### DIFF
--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -95,7 +95,11 @@ public final class UberMatchers {
 	public static Matcher<Throwable> notExpected() {
 		return ThrowableMatcher.notExpected();
 	}
-
+	
+	/**
+	 * Create a matcher that will check that a collection contains the specified item.
+	 * Specified predicate is used to check elements equality.
+	 */
 	public static <T> Matcher<Collection<? extends T>> hasItem(T item, BiPredicate<T, T> matcher) {
 		Objects.requireNonNull(matcher, "Predicate cannot be null!");
 		return new FunctionalMatcher<Collection<? extends T>>(

--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -1,12 +1,18 @@
 package org.whaka.asserts;
 
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.BiPredicate;
 import java.util.regex.Pattern;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.whaka.asserts.matcher.ConsistencyMatcher;
+import org.whaka.asserts.matcher.FunctionalMatcher;
 import org.whaka.asserts.matcher.RegexpMatcher;
 import org.whaka.asserts.matcher.ThrowableMatcher;
+import org.whaka.util.UberCollections;
+import org.whaka.util.reflection.UberClasses;
 
 
 /**
@@ -88,5 +94,13 @@ public final class UberMatchers {
 	 */
 	public static Matcher<Throwable> notExpected() {
 		return ThrowableMatcher.notExpected();
+	}
+
+	public static <T> Matcher<Collection<? extends T>> hasItem(T item, BiPredicate<T, T> matcher) {
+		Objects.requireNonNull(matcher, "Predicate cannot be null!");
+		return new FunctionalMatcher<Collection<? extends T>>(
+				UberClasses.cast(Collection.class),
+				c -> UberCollections.contains(c, item, matcher),
+				d -> d.appendText("has item ").appendValue(item).appendText(" with a predicate"));
 	}
 }

--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -13,6 +13,8 @@ import org.whaka.asserts.matcher.RegexpMatcher;
 import org.whaka.asserts.matcher.ThrowableMatcher;
 import org.whaka.util.UberCollections;
 
+import com.google.common.base.Preconditions;
+
 
 /**
  * Class provides static factory methods for custom Hamcrest matchers provided by the librabry.
@@ -109,6 +111,40 @@ public final class UberMatchers {
 				Collection.class,
 				c -> UberCollections.contains(c, item, matcher),
 				d -> d.appendText("has item ").appendValue(item).appendText(" with a predicate"));
+	}
+	
+	/**
+	 * Equal to {@link #hasAnyItem(Collection, BiPredicate)} with {@link Objects#deepEquals(Object, Object)}
+	 * used as a predicate.
+	 * 
+	 * <p><b>Note:</b> matcher will throw an NPE if matched against a <code>null</code> value!
+	 * 
+	 * @throws NullPointerException if specified collection is <code>null</code>
+	 * @throws IllegalArgumentException if specified collection is <code>empty</code>
+	 */
+	public static <T> Matcher<Collection<? extends T>> hasAnyItem(Collection<T> items) {
+		return hasAnyItem(items, Objects::deepEquals);
+	}
+	
+	/**
+	 * <p>Create a matcher that will check that a collection contains any one of the specified item.
+	 * Specified predicate is used to check elements equality.
+	 * 
+	 * <p><b>Note:</b> matcher will throw an NPE if matched against a <code>null</code> value!
+	 * 
+	 * @throws NullPointerException if specified collection or specified predicate is <code>null</code>
+	 * @throws IllegalArgumentException if specified collection is <code>empty</code>
+	 * 
+	 * @see #hasAnyItem(Collection)
+	 */
+	public static <T> Matcher<Collection<? extends T>> hasAnyItem(Collection<T> items, BiPredicate<T, T> matcher) {
+		Objects.requireNonNull(items, "Items collection cannot be null!");
+		Objects.requireNonNull(matcher, "Predicate cannot be null!");
+		Preconditions.checkArgument(!items.isEmpty(), "Items cannot be empty!");
+		return new FunctionalMatcher<Collection<? extends T>>(
+				Collection.class,
+				c -> UberCollections.containsAny(c, items, matcher),
+				d -> d.appendText("has any one of ").appendValue(items).appendText(" with a predicate"));
 	}
 
 	/**

--- a/src/main/java/org/whaka/asserts/UberMatchers.java
+++ b/src/main/java/org/whaka/asserts/UberMatchers.java
@@ -12,7 +12,6 @@ import org.whaka.asserts.matcher.FunctionalMatcher;
 import org.whaka.asserts.matcher.RegexpMatcher;
 import org.whaka.asserts.matcher.ThrowableMatcher;
 import org.whaka.util.UberCollections;
-import org.whaka.util.reflection.UberClasses;
 
 
 /**
@@ -95,16 +94,35 @@ public final class UberMatchers {
 	public static Matcher<Throwable> notExpected() {
 		return ThrowableMatcher.notExpected();
 	}
-	
+
 	/**
-	 * Create a matcher that will check that a collection contains the specified item.
+	 * <p>Create a matcher that will check that a collection contains the specified item.
 	 * Specified predicate is used to check elements equality.
+	 * 
+	 * <p><b>Note:</b> matcher will throw an NPE if matched against a <code>null</code> value!
+	 * 
+	 * @throws NullPointerException if specified predicate is <code>null</code>
 	 */
 	public static <T> Matcher<Collection<? extends T>> hasItem(T item, BiPredicate<T, T> matcher) {
 		Objects.requireNonNull(matcher, "Predicate cannot be null!");
 		return new FunctionalMatcher<Collection<? extends T>>(
-				UberClasses.cast(Collection.class),
+				Collection.class,
 				c -> UberCollections.contains(c, item, matcher),
 				d -> d.appendText("has item ").appendValue(item).appendText(" with a predicate"));
+	}
+
+	/**
+	 * Create a matcher that will check that an item is contained in the specified collection.
+	 * Specified predicate is used to check elements equality.
+	 * 
+	 * @throws NullPointerException if specified collection or predicate is <code>null</code>
+	 */
+	public static <T> Matcher<T> isIn(Collection<? extends T> col, BiPredicate<T, T> matcher) {
+		Objects.requireNonNull(col, "Collection cannot be null!");
+		Objects.requireNonNull(matcher, "Predicate cannot be null!");
+		return new FunctionalMatcher<T>(
+				Object.class,
+				t -> UberCollections.contains(col, t, matcher),
+				d -> d.appendText("one of ").appendValue(col).appendText(" with a predicate"));
 	}
 }

--- a/src/main/java/org/whaka/asserts/matcher/FunctionalMatcher.java
+++ b/src/main/java/org/whaka/asserts/matcher/FunctionalMatcher.java
@@ -24,7 +24,7 @@ import org.hamcrest.Matcher;
  */
 public class FunctionalMatcher<T> extends BaseMatcher<T> {
 
-	private final Class<T> type;
+	private final Class<? super T> type;
 	private final Predicate<T> predicate;
 	private final Consumer<Description> describer;
 	
@@ -33,7 +33,7 @@ public class FunctionalMatcher<T> extends BaseMatcher<T> {
 	 * consumer that calls {@link Description#appendText(String)} with the specified string.
 	 * 
 	 */
-	public FunctionalMatcher(Class<T> type, Predicate<T> predicate, String description) {
+	public FunctionalMatcher(Class<? super T> type, Predicate<T> predicate, String description) {
 		this(type, predicate, d -> d.appendText(description));
 	}
 	
@@ -46,13 +46,13 @@ public class FunctionalMatcher<T> extends BaseMatcher<T> {
 	 * 
 	 * @see #FunctionalMatcher(Class, Predicate, String)
 	 */
-	public FunctionalMatcher(Class<T> type, Predicate<T> predicate, Consumer<Description> describer) {
+	public FunctionalMatcher(Class<? super T> type, Predicate<T> predicate, Consumer<Description> describer) {
 		this.type = Objects.requireNonNull(type, "type");
 		this.predicate = Objects.requireNonNull(predicate, "predicate");
 		this.describer = Objects.requireNonNull(describer, "describer");
 	}
 	
-	public Class<T> getType() {
+	public Class<? super T> getType() {
 		return type;
 	}
 	

--- a/src/test/groovy/org/whaka/asserts/UberMatchersTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/UberMatchersTest.groovy
@@ -1,0 +1,64 @@
+package org.whaka.asserts
+
+import java.util.function.BiPredicate
+
+import org.hamcrest.Matcher
+
+import spock.lang.Specification
+
+class UberMatchersTest extends Specification {
+
+	def "hasItem with predicate: basics"() {
+		given:
+			BiPredicate predicate = Mock()
+			Matcher m = UberMatchers.hasItem("item", predicate)
+			List<String> values = ["qwe", "rty", "qaz", "pop"]
+		when:
+			def res = m.matches(values)
+		then:
+			1 * predicate.test("qwe", "item") >> false
+		and:
+			1 * predicate.test("rty", "item") >> false
+		and:
+			1 * predicate.test("qaz", "item") >> true
+		and:
+			0 * predicate.test(_, _)
+		and:
+			res == true
+	}
+
+	def "hasItem with predicate: examples"() {
+		given:
+			Matcher m = UberMatchers.hasItem(item, predicate)
+		expect:
+			m.matches(values as List) == result
+		where:
+			values				|	item		|	predicate				||	result
+			[]					|	3			|	Objects.&equals			||	false
+			[]					|	3			|	{a,b -> true}			||	false
+			[1,2]				|	3			|	Objects.&equals			||	false
+			[1,2]				|	3			|	{a,b -> true}			||	true
+			[1,2,3]				|	3			|	Objects.&equals			||	true
+			[1,2,3]				|	3			|	{a,b -> false}			||	false
+			[]					|	null		|	Objects.&equals			||	false
+			[null]				|	null		|	Objects.&equals			||	true
+			[null, null]		|	null		|	Objects.&equals			||	true
+	}
+
+	def "hasItem with predicate: NPE"() {
+
+		when:
+			UberMatchers.hasItem(null, Mock(BiPredicate))
+		then:
+			notThrown()
+
+		when:
+			UberMatchers.hasItem(42, null)
+		then:
+			thrown(NullPointerException)
+	}
+
+	private static int[] arr(int[] arr) {
+		return arr
+	}
+}

--- a/src/test/groovy/org/whaka/asserts/UberMatchersTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/UberMatchersTest.groovy
@@ -47,13 +47,18 @@ class UberMatchersTest extends Specification {
 
 	def "hasItem with predicate: NPE"() {
 
-		when:
+		when: "item is null, but predicate is valid"
 			UberMatchers.hasItem(null, Mock(BiPredicate))
-		then:
+		then: "nothing is thrown - null value is searched"
 			notThrown()
 
-		when:
+		when: "predicate is null"
 			UberMatchers.hasItem(42, null)
+		then:
+			thrown(NullPointerException)
+
+		when: "properly created matcher is called upon null value as a collection"
+			UberMatchers.hasItem(42, {a,b->true}).matches(null as Collection)
 		then:
 			thrown(NullPointerException)
 	}

--- a/src/test/groovy/org/whaka/asserts/UberMatchersTest.groovy
+++ b/src/test/groovy/org/whaka/asserts/UberMatchersTest.groovy
@@ -43,6 +43,8 @@ class UberMatchersTest extends Specification {
 			[]					|	null		|	Objects.&equals			||	false
 			[null]				|	null		|	Objects.&equals			||	true
 			[null, null]		|	null		|	Objects.&equals			||	true
+			[arr(1,2),arr(3,4)]	|	arr(1,2)	|	Objects.&equals			||	false
+			[arr(1,2),arr(3,4)]	|	arr(1,2)	|	Objects.&deepEquals		||	true
 	}
 
 	def "hasItem with predicate: NPE"() {
@@ -59,6 +61,57 @@ class UberMatchersTest extends Specification {
 
 		when: "properly created matcher is called upon null value as a collection"
 			UberMatchers.hasItem(42, {a,b->true}).matches(null as Collection)
+		then:
+			thrown(NullPointerException)
+	}
+
+	def "isIn with predicate: basics"() {
+		given:
+			BiPredicate predicate = Mock()
+			Matcher m = UberMatchers.isIn(["qwe", "rty", "qaz", "pop"], predicate)
+		when:
+			def res = m.matches("item")
+		then:
+			1 * predicate.test("qwe", "item") >> false
+		and:
+			1 * predicate.test("rty", "item") >> false
+		and:
+			1 * predicate.test("qaz", "item") >> true
+		and:
+			0 * predicate.test(_, _)
+		and:
+			res == true
+	}
+
+	def "isIn with predicate: examples"() {
+		given:
+			Matcher m = UberMatchers.isIn(values as List, predicate)
+		expect:
+			m.matches(item) == result
+		where:
+			values				|	item		|	predicate				||	result
+			[]					|	3			|	Objects.&equals			||	false
+			[]					|	3			|	{a,b -> true}			||	false
+			[1,2]				|	3			|	Objects.&equals			||	false
+			[1,2]				|	3			|	{a,b -> true}			||	true
+			[1,2,3]				|	3			|	Objects.&equals			||	true
+			[1,2,3]				|	3			|	{a,b -> false}			||	false
+			[]					|	null		|	Objects.&equals			||	false
+			[null]				|	null		|	Objects.&equals			||	true
+			[null, null]		|	null		|	Objects.&equals			||	true
+			[arr(1,2),arr(3,4)]	|	arr(1,2)	|	Objects.&equals			||	false
+			[arr(1,2),arr(3,4)]	|	arr(1,2)	|	Objects.&deepEquals		||	true
+	}
+
+	def "isIn with predicate: NPE"() {
+
+		when: "collection is null"
+			UberMatchers.isIn(null, Mock(BiPredicate))
+		then:
+			thrown(NullPointerException)
+
+		when: "predicate is null"
+			UberMatchers.isIn([], null)
 		then:
 			thrown(NullPointerException)
 	}


### PR DESCRIPTION
- Resolve #42 [Assert] Create "hasAnyItem" matcher with BiPredicate
- Resolve #41 [Assert] Create "hasAnyItem" matcher
# 
1. `UberMatchers.hasAnyItem(Collection<T>,BiPredicate<T,T>)` is implemented
2. `UberMatchers.hasAnyItem(Collection<T>)` is implemented

`FunctionalMatcher` and `UberCollections` were used for implementation.
